### PR TITLE
Add Basic Deploy Oven Modal

### DIFF
--- a/src/contracts/WrappedTezos/components/Mint/DeployOvenButtonWrapper.tsx
+++ b/src/contracts/WrappedTezos/components/Mint/DeployOvenButtonWrapper.tsx
@@ -1,13 +1,37 @@
 import React from 'react';
 import { Container } from '../style';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
+import { setModalOpen, clearModal } from '../../../../reduxContent/modal/actions';
+import { RootState } from '../../../../types/store';
+import DeployOvenModal from './DeployOvenModal';
+
+import { AddCircleWrapper } from './style';
+
+const ADD_OVEN_MODAL_IDENTIFIER = 'add_oven';
 
 /** Renders a wrapper around a component that includes a "Deploy Oven" button */
 const DeployOvenButtonWrapper = (props) => {
     const { children } = props;
+
+    const dispatch = useDispatch();
+
+    function setIsModalOpen(open, active) {
+        dispatch(setModalOpen(open, active));
+        if (!open) {
+            dispatch(clearModal());
+        }
+    }
+
+    const activeModal = useSelector<RootState, string>((state) => state.modal.activeModal);
+    const isModalOpen = useSelector<RootState, boolean>((state) => state.modal.open);
+
+    const isAddOvenModalOpen = isModalOpen && activeModal === ADD_OVEN_MODAL_IDENTIFIER;
+
     return (
         <Container>
-            {/* TODO(keefertaylor): Wire this button to a modal */}
-            <button>Deploy Oven</button>
+            {isAddOvenModalOpen && <DeployOvenModal open={isAddOvenModalOpen} onClose={() => setIsModalOpen(false, ADD_OVEN_MODAL_IDENTIFIER)} />}
+
+            <AddCircleWrapper active={1} onClick={() => dispatch(setModalOpen(true, ADD_OVEN_MODAL_IDENTIFIER))} />
             {children}
         </Container>
     );

--- a/src/contracts/WrappedTezos/components/Mint/DeployOvenModal.tsx
+++ b/src/contracts/WrappedTezos/components/Mint/DeployOvenModal.tsx
@@ -36,7 +36,7 @@ function DeployOvenModal(props: DeployOvenModalProps) {
 
     return (
         <Modal title="Deploy Oven" open={props.open} onClose={onCloseClick}>
-            Please note: deploying a new oven incurs fees.
+            <p>Please note: deploying a new oven incurs fees.</p>
             <InvokeButton buttonTheme="primary" disabled={isDisabled} onClick={() => deployOven()}>
                 {/* TODO(keefertaylor): Use translations here */}
                 Deploy Oven

--- a/src/contracts/WrappedTezos/components/Mint/DeployOvenModal.tsx
+++ b/src/contracts/WrappedTezos/components/Mint/DeployOvenModal.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
+
+import { RootState } from '../../../../types/store';
+import Modal from '../../../../components/CustomModal';
+import { InvokeButton } from './style';
+import { setIsLoadingAction } from '../../../../reduxContent/app/actions';
+
+type DeployOvenModalProps = {
+    // Whether the modal is open.
+    open: boolean;
+
+    // A handler that will close the modal.
+    onClose: () => void;
+};
+
+/** A modal for depoying ovens. */
+function DeployOvenModal(props: DeployOvenModalProps) {
+    const dispatch = useDispatch();
+    const { isLoading } = useSelector((rootState: RootState) => rootState.app, shallowEqual);
+
+    const isDisabled = isLoading;
+
+    const onCloseClick = () => {
+        props.onClose();
+    };
+
+    const deployOven = () => {
+        dispatch(setIsLoadingAction(true));
+
+        // TODO(keefertaylor): Add a thunk to deploy an oven.
+
+        dispatch(setIsLoadingAction(false));
+        props.onClose();
+    };
+
+    return (
+        <Modal title="Deploy Oven" open={props.open} onClose={onCloseClick}>
+            Please note: deploying a new oven incurs fees.
+            <InvokeButton buttonTheme="primary" disabled={isDisabled} onClick={() => deployOven()}>
+                {/* TODO(keefertaylor): Use translations here */}
+                Deploy Oven
+            </InvokeButton>
+        </Modal>
+    );
+}
+
+export default DeployOvenModal;

--- a/src/contracts/WrappedTezos/components/Mint/style.ts
+++ b/src/contracts/WrappedTezos/components/Mint/style.ts
@@ -1,0 +1,23 @@
+import AddCircle from '@material-ui/icons/AddCircle';
+import styled from 'styled-components';
+import { ms } from '../../../../styles/helpers';
+import Button from '../../../../components/Button';
+
+export const AddCircleWrapper = styled(AddCircle)<{ active: number }>`
+    &&& {
+        fill: #7b91c0;
+        width: ${ms(1.5)};
+        height: ${ms(1.5)};
+        opacity: ${({ active }) => (active ? 1 : 0.5)};
+        cursor: ${({ active }) => (active ? 'pointer' : 'default')};
+        margin-right: ${({ active }) => (active ? '5px' : '0px')};
+    }
+`;
+
+export const InvokeButton = styled(Button)`
+    width: 194px;
+    height: 50px;
+    margin-bottom: 0px;
+    margin-left: auto;
+    padding: 0;
+`;


### PR DESCRIPTION
Some basic wiring for a deploy oven modal:
- Stylize modal button to be the standard '+' icon
- Build a basic modal

Screenshots:
<img width="1232" alt="Screen Shot 2020-12-09 at 3 23 58 PM" src="https://user-images.githubusercontent.com/18271723/101696783-7bcd7800-3a2b-11eb-8ea9-b219c4e62007.png">
<img width="1232" alt="Screen Shot 2020-12-09 at 3 23 56 PM" src="https://user-images.githubusercontent.com/18271723/101696816-88ea6700-3a2b-11eb-9c4e-5ab1f9a40c70.png">
