### PR TITLE
Fix Units in Withdraw Dialog

### DIFF
--- a/src/contracts/WrappedTezos/components/Mint/WithdrawModal.tsx
+++ b/src/contracts/WrappedTezos/components/Mint/WithdrawModal.tsx
@@ -6,6 +6,8 @@ import { OperationKindType } from 'conseiljs';
 import IconButton from '@material-ui/core/IconButton';
 import TextField from '../../../../components/TextField';
 import TezosNumericInput from '../../../../components/TezosNumericInput';
+import NumericInput from '../../../../components/NumericInput';
+import { BigNumber } from 'bignumber.js';
 
 import Modal from '../../../../components/CustomModal';
 import Tooltip from '../../../../components/Tooltip/';
@@ -382,6 +384,16 @@ function DepositModal(props: Props) {
                             label={t('general.nouns.amount')}
                             amount={wxtzToWithdraw}
                             onChange={changeWxtzToWithdraw}
+                        />
+                        <NumericInput
+                            label={t('general.nouns.amount')}
+                            amount={wxtzToWithdraw}
+                            onChange={changeWxtzToWithdraw}
+                            symbol={'wXTZ'}
+                            scale={6}
+                            precision={6}
+                            maxValue={new BigNumber(wrappedTezBalance).dividedBy(10 ** (6 || 0)).toNumber()}
+                            minValue={new BigNumber(1).dividedBy(10 ** (6 || 0)).toNumber()}
                         />
                         <UseMax onClick={onUseMax}>{t('general.verbs.use_max')}</UseMax>
                     </AmountSendContainer>


### PR DESCRIPTION
Fix units in the withdraw dialog that read as "TZ" to `wXTZ`.

Also piggy back

Screenshot:
<img width="1232" alt="Screen Shot 2020-12-16 at 5 10 21 PM" src="https://user-images.githubusercontent.com/18271723/102421517-6fac6200-3fb9-11eb-9ffb-df508734d966.png">
 some build fixes. 