### PR TITLE
toformat/tofixed

### DIFF
--- a/src/components/NumericInput/index.tsx
+++ b/src/components/NumericInput/index.tsx
@@ -33,7 +33,7 @@ const NumericInput = (props: Props) => {
             return;
         }
 
-        onChange(b.toFormat(precision));
+        onChange(b.toFixed(precision));
     }
 
     return (

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -22,5 +22,5 @@ export function formatAmount(amount, decimal: number = 6) {
     const b = new BigNumber(amount);
     const m = b.dividedBy(utez);
 
-    return m.toFormat(decimal);
+    return m.toFixed(decimal);
 }


### PR DESCRIPTION
Because `new BigNumber(new BigNumber('9000').toFormat(6))` -> `NaN`. 🤦🏻‍♂️ as of bignumber.js 9.0.1.