### PR TITLE
Fix for failing Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ node_js:
 cache:
     directories:
         - node_modules
+        
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install libusb-1.0-0-dev
 
 before_script:
     - export DISPLAY=':99.0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,3 @@ before_script:
 
 script:
     - npm run package
-
-after_success:
-    - npm run coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ cache:
 before_install:
   - sudo apt-get update
   - sudo apt-get -y install libusb-1.0-0-dev
+  - sudo apt-get -y install libudev-dev
 
 before_script:
     - export DISPLAY=':99.0'


### PR DESCRIPTION
Ensuring some missing dependencies are fixed. 

Closes #332 

I had to disable the coverage check because we have no real active tests to speak of. #335 is intended to fix this. 