### PR TITLE
Rename liquidity baking DEX to Sirius

### DIFF
--- a/src/constants/Token.ts
+++ b/src/constants/Token.ts
@@ -1821,7 +1821,7 @@ export const knownContractNames = {
     KT1D56HQfMmwdopmFLTwNHFJSs6Dsg2didFo: 'Dexter wXTZ Pool',
     KT1AbYeDbjjcAnV1QK7EZUUdqku77CdkTuv6: 'Dexter kUSD Pool',
 
-    KT1TxqZ8QtKvLu3V3JH7Gx58n7Co8pgtpQU5: 'Granada tzBTC Pool',
+    KT1TxqZ8QtKvLu3V3JH7Gx58n7Co8pgtpQU5: 'Sirius tzBTC Pool',
 
     KT1WxgZ1ZSfMgmsSDDcUn8Xn577HwnQ7e1Lb: 'QuipuSwap USDtz Pool',
     KT1K4EwTpbvYN9agJdjpyJm4ZZdhpUNKB3F6: 'QuipuSwap kUSD Pool',
@@ -1959,9 +1959,9 @@ export const knownContractNames = {
     KT1Dq4XtyD83Bm7Nn4PMxj9MDp2n9HXijqkx: 'PixelDebates Tactics Claims',
     KT1Qm7MHmbdiBzoRs7xqBiqoRxw7T2cxTTJN: 'Mooncakes',
     KT1CzVSa18hndYupV9NcXy3Qj7p8YFDZKVQv: 'Mooncakes v2',
-    KT19oLahfvtuEHWBGzWKYuUqpt2s78isuPvq: "Ottez Gen2 Fusion",
-    KT1QXngq1CCuWv5RtnuYCSvGdKGeBxsRCWvQ: "Decathlon NFT",
-    KT1JBNFcB5tiycHNdYGYCtR3kk6JaJysUCi8: "EURL"
+    KT19oLahfvtuEHWBGzWKYuUqpt2s78isuPvq: 'Ottez Gen2 Fusion',
+    KT1QXngq1CCuWv5RtnuYCSvGdKGeBxsRCWvQ: 'Decathlon NFT',
+    KT1JBNFcB5tiycHNdYGYCtR3kk6JaJysUCi8: 'EURL',
 };
 
 export const knownMarketMetadata = [
@@ -1993,7 +1993,7 @@ export const knownMarketMetadata = [
         network: 'mainnet',
         address: 'KT1TxqZ8QtKvLu3V3JH7Gx58n7Co8pgtpQU5',
         token: 'KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn',
-        name: 'Granada tzBTC Pool',
+        name: 'Sirius tzBTC Pool',
         scale: 8,
         symbol: 'tzBTC',
     },

--- a/src/containers/PlatformLiquidity/container.tsx
+++ b/src/containers/PlatformLiquidity/container.tsx
@@ -318,7 +318,7 @@ const PlatformLiquidity = () => {
                             size={ms(4.5)}
                             amount={ammTokenBalance}
                             weight="light"
-                            symbol={'LP'}
+                            symbol={'SIRS'}
                             showTooltip={true}
                             scale={6}
                             precision={6}
@@ -379,7 +379,7 @@ const PlatformLiquidity = () => {
                                         amount={lpAmount}
                                         onChange={updateLPAmount}
                                         errorText={lpError}
-                                        symbol={'LP'}
+                                        symbol={'SIRS'}
                                         scale={6}
                                         precision={6}
                                     />

--- a/src/contracts/components/Swap/index.tsx
+++ b/src/contracts/components/Swap/index.tsx
@@ -392,7 +392,7 @@ function Swap(props: Props) {
                             <div style={{ alignItems: 'left' }}>
                                 {tokenAmount.length > 0 && tokenAmount !== '0' && tradeSide === 'buy' && dexterTokenCost > 0 && (
                                     <div>
-                                        Cost {quipuTokenCost > 0 ? (token.symbol.toLocaleLowerCase() === 'tzbtc' ? ' on GranadaSwap' : 'on Dexter') : ''}{' '}
+                                        Cost {quipuTokenCost > 0 ? (token.symbol.toLocaleLowerCase() === 'tzbtc' ? ' on Sirius' : 'on Dexter') : ''}{' '}
                                         {formatAmount(dexterTokenCost)} XTZ
                                     </div>
                                 )}
@@ -405,8 +405,7 @@ function Swap(props: Props) {
 
                                 {tokenAmount.length > 0 && tokenAmount !== '0' && tradeSide === 'sell' && dexterTokenProceeds > 0 && (
                                     <div>
-                                        Proceeds{' '}
-                                        {quipuTokenProceeds > 0 ? (token.symbol.toLocaleLowerCase() === 'tzbtc' ? ' on GranadaSwap' : 'on Dexter') : ''}{' '}
+                                        Proceeds {quipuTokenProceeds > 0 ? (token.symbol.toLocaleLowerCase() === 'tzbtc' ? ' on Sirius' : 'on Dexter') : ''}{' '}
                                         {formatAmount(dexterTokenProceeds)} XTZ
                                     </div>
                                 )}
@@ -442,8 +441,7 @@ function Swap(props: Props) {
                     {bestMarket && bestMarket.length > 0 && (
                         <>
                             {' '}
-                            {t('general.prepositions.on')}{' '}
-                            {bestMarket === 'Dexter' && token.symbol.toLocaleLowerCase() === 'tzbtc' ? 'Granada Swap' : bestMarket}
+                            {t('general.prepositions.on')} {bestMarket === 'Dexter' && token.symbol.toLocaleLowerCase() === 'tzbtc' ? 'Sirius' : bestMarket}
                         </>
                     )}
                 </InvokeButton>


### PR DESCRIPTION
As described at https://siriustoken.io/, the liquidity baking DEX is now called Sirius. 